### PR TITLE
Update ItemModel with translation support

### DIFF
--- a/lib/data/model/item/item_model.dart
+++ b/lib/data/model/item/item_model.dart
@@ -5,8 +5,10 @@ import 'package:Talab/data/model/seller_ratings_model.dart';
 class ItemModel {
   int? id;
   String? name;
+  String? translatedName;
   String? slug;
   String? description;
+  String? translatedDescription;
   double? price;
   String? image;
   dynamic watermarkimage;
@@ -71,9 +73,11 @@ class ItemModel {
   ItemModel(
       {this.id,
       this.name,
+      this.translatedName,
       this.slug,
       this.category,
       this.description,
+      this.translatedDescription,
       this.price,
       this.image,
       this.watermarkimage,
@@ -116,8 +120,10 @@ class ItemModel {
   ItemModel copyWith(
       {int? id,
       String? name,
+      String? translatedName,
       String? slug,
       String? description,
+      String? translatedDescription,
       double? price,
       String? image,
       dynamic watermarkimage,
@@ -155,9 +161,12 @@ class ItemModel {
     return ItemModel(
       id: id ?? this.id,
       name: name ?? this.name,
+      translatedName: translatedName ?? this.translatedName,
       slug: slug ?? this.slug,
       category: category ?? this.category,
       description: description ?? this.description,
+      translatedDescription:
+          translatedDescription ?? this.translatedDescription,
       price: price ?? this.price,
       image: image ?? this.image,
       watermarkimage: watermarkimage ?? this.watermarkimage,
@@ -217,14 +226,16 @@ class ItemModel {
     }
 
     id = json['id'];
-    name = json['name'];
+    translatedName = json['translated_name'];
+    translatedDescription = json['translated_description'];
+    name = json['translated_name'] ?? json['name'];
     slug = json['slug'];
     category = json['category'] != null
         ? CategoryModel.fromJson(json['category'])
         : null;
     totalLikes = json['total_likes'];
     views = json['clicks'];
-    description = json['description'];
+    description = json['translated_description'] ?? json['description'];
 language = json['language'];
     image = json['image'];
     watermarkimage = json['watermark_image'];
@@ -281,8 +292,10 @@ language = json['language'];
     final Map<String, dynamic> data = <String, dynamic>{};
     data['id'] = id;
     data['name'] = name;
+    data['translated_name'] = translatedName;
     data['slug'] = slug;
     data['description'] = description;
+    data['translated_description'] = translatedDescription;
     data['price'] = price;
     data['total_likes'] = totalLikes;
     data['clicks'] = views;

--- a/lib/ui/screens/ad_details_screen.dart
+++ b/lib/ui/screens/ad_details_screen.dart
@@ -466,7 +466,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
                       Padding(
                           padding: const EdgeInsets.symmetric(vertical: 10),
                           child: CustomText(
-                            model.name!,
+                            model.translatedName ?? model.name!,
                             color: context.color.textDefaultColor,
                             fontSize: context.font.large,
                             maxLines: 2,
@@ -966,7 +966,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               CustomText(
-                model.name!,
+                model.translatedName ?? model.name!,
                 firstUpperCaseWidget: true,
                 fontWeight: FontWeight.w600,
                 fontSize: context.font.large,
@@ -1022,7 +1022,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               CustomText(
-                model.name!,
+                model.translatedName ?? model.name!,
                 firstUpperCaseWidget: true,
                 fontWeight: FontWeight.w600,
                 fontSize: context.font.large,
@@ -1350,7 +1350,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
                     arguments: {
                       "itemId": model.id,
                       "price": model.price,
-                      "itemName": model.name,
+                      "itemName": model.translatedName ?? model.name,
                       "itemImage": model.image
                     });
               }, null, null),
@@ -1488,7 +1488,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
                         itemImage: model.image!,
                         itemId: model.id.toString(),
                         date: model.created!,
-                        itemTitle: model.name!,
+                        itemTitle: model.translatedName ?? model.name!,
                         itemOfferId: state.data['id'],
                         itemPrice: model.price!,
                         status: model.status!,
@@ -2217,7 +2217,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 5.0),
           child: CustomText(
-            model.description!,
+            model.translatedDescription ?? model.description!,
             color: context.color.textDefaultColor.withValues(alpha: 0.5),
           ),
         ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -755,7 +755,7 @@ class _ItemGridCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    item.name ?? "",
+                    item.translatedName ?? item.name ?? "",
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(fontWeight: FontWeight.w600),

--- a/lib/ui/screens/home/widgets/item_horizontal_card.dart
+++ b/lib/ui/screens/home/widgets/item_horizontal_card.dart
@@ -223,7 +223,8 @@ class ItemHorizontalCard extends StatelessWidget {
                                 ],
                               ),
                               CustomText(
-                                item.name!.firstUpperCase(),
+                                (item.translatedName ?? item.name ?? '')
+                                    .firstUpperCase(),
                                 fontSize: fontSizeName,
                                 color: context.color.textDefaultColor,
                                 maxLines: 2,

--- a/lib/ui/screens/item/my_item_tab_screen.dart
+++ b/lib/ui/screens/item/my_item_tab_screen.dart
@@ -359,7 +359,7 @@ class _MyItemTabState extends CloudState<MyItemTab> {
                                         ),
                                         //SizedBox(height: 7,),
                                         CustomText(
-                                          item.name ?? "",
+                                          item.translatedName ?? item.name ?? "",
                                           maxLines: 2,
                                           firstUpperCaseWidget: true,
                                         ),


### PR DESCRIPTION
## Summary
- add `translatedName` and `translatedDescription` fields to `ItemModel`
- default item name and description to the translated values when available
- include these fields in serialization and copyWith
- display translated item title in item list, home screen, my items tab
- show translated title and description in ad details

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444ccc64b883289c06bf14eeb39948