### PR TITLE
Fix search bar sticky in home screen

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -163,6 +163,11 @@ class HomeScreenState extends State<HomeScreen>
         appBar: AppBar(
           elevation: 0,
           backgroundColor: Colors.transparent,
+          bottom: PreferredSize(
+            preferredSize:
+                Size.fromHeight(HomeSearchField.preferredHeight(context)),
+            child: const HomeSearchField(),
+          ),
           actions: [
             _iconButton(
               asset: AppIcons.notification,
@@ -240,7 +245,6 @@ class HomeScreenState extends State<HomeScreen>
                       return Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          const HomeSearchField(),
                           const SliderWidget(),
                           const CategoryWidgetHome(),
                           ...state.sections.map((section) => HomeSectionsAdapter(


### PR DESCRIPTION
## Summary
- pin search bar inside `AppBar` so it stays visible while scrolling

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68447c133f30832899bfc7e8b01899a5