### PR TITLE
Enable clickable banners in featured sections

### DIFF
--- a/lib/data/model/home/home_screen_section.dart
+++ b/lib/data/model/home/home_screen_section.dart
@@ -34,21 +34,31 @@ class HomeScreenSection {
     this.totalData,
     this.sectionData,
   });
-  List<String> get bannerData => bannerImages; 
-  // Getter to parse banner images from value field
-  List<String> get bannerImages {
+
+  /// Parsed banner objects for sections with `filter == "banner"`.
+  List<HomeSlider> get banners {
     if (filter == 'banner' && value != null) {
       try {
-        return List<String>.from(jsonDecode(value!));
-        
+        final decoded = jsonDecode(value!);
+        if (decoded is List) {
+          return decoded.map<HomeSlider>((e) {
+            if (e is String) {
+              return HomeSlider(image: e);
+            } else if (e is Map<String, dynamic>) {
+              return HomeSlider.fromJson(e);
+            }
+            return HomeSlider();
+          }).toList();
+        }
       } catch (e) {
-        print('Error decoding banner images: $e');
-        return [];
+        print('Error decoding banner data: $e');
       }
     }
     return [];
   }
 
+  /// Convenience getter returning just the banner image URLs.
+  List<String> get bannerImages => banners.map((e) => e.image ?? '').toList();
   HomeScreenSection.fromJson(Map<String, dynamic> json) {
     sectionId = json['id'];
     title = json['title'];


### PR DESCRIPTION
## Summary
- parse banner objects from section `value`
- add onTap behavior to banner carousel
- support navigation to categories, items or external links

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454a51e3188328a9fbb20aafa13239