### PR TITLE
Fix missing import of HomeSlider

### DIFF
--- a/lib/data/model/home/home_screen_section.dart
+++ b/lib/data/model/home/home_screen_section.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:Talab/data/model/item/item_model.dart';
+import 'package:Talab/data/model/home_slider.dart';
 
 
 class HomeScreenSection {

--- a/lib/ui/screens/home/widgets/banner_section_widget.dart
+++ b/lib/ui/screens/home/widgets/banner_section_widget.dart
@@ -7,6 +7,7 @@ import 'package:Talab/data/model/category_model.dart';
 import 'package:Talab/data/model/data_output.dart';
 import 'package:Talab/data/model/home/home_screen_section.dart';
 import 'package:Talab/data/model/item/item_model.dart';
+import 'package:Talab/data/model/home_slider.dart';
 import 'package:Talab/data/repositories/item/item_repository.dart';
 import 'package:Talab/ui/theme/theme.dart';
 import 'package:Talab/utils/app_icon.dart';


### PR DESCRIPTION
## Summary
- add HomeSlider import to HomeScreenSection model
- add HomeSlider import to banner widget

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455521383483289c21e41c05266a6c