### PR TITLE
Add hero animations for item transitions

### DIFF
--- a/lib/ui/screens/ad_details_screen.dart
+++ b/lib/ui/screens/ad_details_screen.dart
@@ -1741,12 +1741,14 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
 
 //ImageView
   Widget setImageViewer() {
-    return Container(
-      height: 369,
-      decoration: BoxDecoration(borderRadius: BorderRadius.circular(18)),
-      padding: const EdgeInsets.symmetric(vertical: 10),
-      // decoration: BoxDecoration(borderRadius: BorderRadius.circular(20)),
-      child: ClipRRect(
+    return Hero(
+      tag: 'item_\${model.id}',
+      child: Container(
+        height: 369,
+        decoration: BoxDecoration(borderRadius: BorderRadius.circular(18)),
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        // decoration: BoxDecoration(borderRadius: BorderRadius.circular(20)),
+        child: ClipRRect(
         borderRadius: BorderRadius.circular(18),
         child: Stack(children: [
           PageView.builder(

--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -749,11 +749,14 @@ class _ItemCardState extends State<ItemCard> {
                 // IMAGE
                 ClipRRect(
                   borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-                  child: UiUtils.getImage(
-                    widget.item?.image ?? "",
-                    height: imageHeight,
-                    width: double.infinity,
-                    fit: BoxFit.cover,
+                  child: Hero(
+                    tag: 'item_\${widget.item?.id}',
+                    child: UiUtils.getImage(
+                      widget.item?.image ?? "",
+                      height: imageHeight,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    ),
                   ),
                 ),
 

--- a/lib/ui/screens/home/widgets/item_horizontal_card.dart
+++ b/lib/ui/screens/home/widgets/item_horizontal_card.dart
@@ -163,13 +163,16 @@ class ItemHorizontalCard extends StatelessWidget {
                         children: [
                           Stack(
                             children: [
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(borderRadius),
-                                child: UiUtils.getImage(
-                                  item.image ?? "",
-                                  height: imageHeight,
-                                  width: imageWidth + (additionalImageWidth ?? 0),
-                                  fit: BoxFit.cover,
+                              Hero(
+                                tag: 'item_\${item.id}',
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(borderRadius),
+                                  child: UiUtils.getImage(
+                                    item.image ?? "",
+                                    height: imageHeight,
+                                    width: imageWidth + (additionalImageWidth ?? 0),
+                                    fit: BoxFit.cover,
+                                  ),
                                 ),
                               ),
                               if (item.isFeature ?? false)


### PR DESCRIPTION
## Summary
- wrap item images with `Hero` widgets in item cards
- wrap detail page image viewer with matching `Hero` widget

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469998c34c83289637955cb43f725f