### PR TITLE
Improve hero animation with fade scale transition

### DIFF
--- a/lib/ui/screens/widgets/animated_routes/fade_scale_route.dart
+++ b/lib/ui/screens/widgets/animated_routes/fade_scale_route.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// A simple page route that fades and slightly scales the page when pushed.
+class FadeScaleRoute<T> extends PageRouteBuilder<T> {
+  final Widget page;
+  FadeScaleRoute({required this.page})
+      : super(
+          pageBuilder: (_, __, ___) => page,
+          transitionDuration: const Duration(milliseconds: 400),
+          transitionsBuilder: (_, animation, __, child) {
+            final curved = CurvedAnimation(parent: animation, curve: Curves.easeInOut);
+            return FadeTransition(
+              opacity: curved,
+              child: ScaleTransition(
+                scale: Tween<double>(begin: 0.9, end: 1).animate(curved),
+                child: child,
+              ),
+            );
+          },
+        );
+}

--- a/lib/utils/custom_hero_animation.dart
+++ b/lib/utils/custom_hero_animation.dart
@@ -1,182 +1,90 @@
-import 'package:Talab/ui/screens/widgets/animated_routes/blur_page_route.dart';
 import 'package:flutter/material.dart';
+import 'package:Talab/ui/screens/widgets/animated_routes/fade_scale_route.dart';
 
+/// Simple widget to show an image in a fullscreen hero view with a
+/// fade and scale transition. This avoids heavy calculations and works
+/// well with sliders or list sections.
 class CustomImageHeroAnimation extends StatefulWidget {
   final Widget child;
   final CImageType type;
   final dynamic image;
 
-  const CustomImageHeroAnimation(
-      {super.key, required this.child, required this.type, this.image});
+  const CustomImageHeroAnimation({
+    super.key,
+    required this.child,
+    required this.type,
+    this.image,
+  });
 
   @override
-  State<CustomImageHeroAnimation> createState() =>
-      _CustomImageHeroAnimationState();
+  State<CustomImageHeroAnimation> createState() => _CustomImageHeroAnimationState();
 }
 
 class _CustomImageHeroAnimationState extends State<CustomImageHeroAnimation> {
-  final GlobalKey _key = GlobalKey();
+  late final String _tag;
 
-  Map<String, double> _getWidgetInfo(BuildContext context, GlobalKey key) {
-    final RenderBox renderBox =
-        key.currentContext?.findRenderObject() as RenderBox;
+  @override
+  void initState() {
+    super.initState();
+    _tag = widget.image?.toString() ?? UniqueKey().toString();
+  }
 
-    final Size size = renderBox.size; // or _widgetKey.currentContext?.size
+  ImageProvider _imageProvider() {
+    switch (widget.type) {
+      case CImageType.Asset:
+        return AssetImage(widget.image);
+      case CImageType.Network:
+        return NetworkImage(widget.image);
+      case CImageType.File:
+        return FileImage(widget.image);
+      case CImageType.Memory:
+        return MemoryImage(widget.image);
+    }
+  }
 
-    final Offset offset = renderBox.localToGlobal(Offset.zero);
-
-    return {
-      "x": (offset.dx),
-      "y": (offset.dy),
-      "width": size.width,
-      "height": size.height,
-      "offX": offset.dx,
-      "offY": offset.dy
-    };
+  void _openPreview() {
+    Navigator.of(context).push(
+      FadeScaleRoute(
+        page: _FullScreenImage(tag: _tag, imageProvider: _imageProvider()),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        Map<String, double> targetWidgetInfo = _getWidgetInfo(context, _key);
-
-        Navigator.push(
-            context,
-            BlurredRouter(
-                builder: (context) {
-                  return _CustomHeroDestinationScreen(
-                    renderWidgetData: targetWidgetInfo,
-                    type: widget.type,
-                    image: widget.image,
-                  );
-                },
-                barrierDismiss: true));
-      },
-      child: Container(
-        key: _key,
+      onTap: _openPreview,
+      child: Hero(
+        tag: _tag,
         child: widget.child,
       ),
     );
   }
 }
 
-enum CImageType { Asset, Network, File, Memory }
+class _FullScreenImage extends StatelessWidget {
+  final String tag;
+  final ImageProvider imageProvider;
 
-class _CustomHeroDestinationScreen extends StatefulWidget {
-  final Map<String, dynamic> renderWidgetData;
-  final CImageType type;
-  final dynamic image;
-  const _CustomHeroDestinationScreen(
-      {required this.renderWidgetData, required this.type, this.image});
-
-  @override
-  State<_CustomHeroDestinationScreen> createState() =>
-      _CustomHeroDestinationScreenState();
-}
-
-class _CustomHeroDestinationScreenState
-    extends State<_CustomHeroDestinationScreen>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _controller = AnimationController(
-      vsync: this, duration: const Duration(milliseconds: 400));
-  late Animation<Offset> _sizeTween;
-  late Animation<Offset> _positionTween;
-  var mediaQuery = const Size(0, 0);
-  @override
-  void didChangeDependencies() {
-    mediaQuery = MediaQuery.of(context).size;
-
-    super.didChangeDependencies();
-  }
-
-  @override
-  void initState() {
-    Future.delayed(
-      Duration.zero,
-      () {
-        mediaQuery = MediaQuery.of(context).size;
-      },
-    );
-
-    var width = widget.renderWidgetData['width'];
-    var height = widget.renderWidgetData['height'];
-
-    _sizeTween =
-        Tween(begin: Offset(width, height), end: const Offset(200, 200))
-            .animate(_controller);
-    Future.delayed(
-      Duration.zero,
-      () {
-        _positionTween = Tween(
-                begin: Offset(
-                    widget.renderWidgetData['x'], widget.renderWidgetData['y']),
-                end: Offset((MediaQuery.of(context).size.width / 2) - (200 / 2),
-                    (MediaQuery.of(context).size.height / 2) - 100))
-            .animate(_controller);
-      },
-    );
-
-    Future.delayed(
-      const Duration(milliseconds: 50),
-      () {
-        _controller.forward();
-      },
-    );
-
-    super.initState();
-  }
-
-  ImageProvider imageTypeAdapeter(CImageType type, dynamic image) {
-    switch (type) {
-      case CImageType.Asset:
-        return AssetImage(image);
-
-      case CImageType.Network:
-        return NetworkImage(image);
-
-      case CImageType.File:
-        return FileImage(image);
-
-      case CImageType.Memory:
-        return MemoryImage(image);
-    }
-  }
+  const _FullScreenImage({required this.tag, required this.imageProvider});
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        Navigator.pop(context);
-      },
-      child: Scaffold(
-        backgroundColor: Colors.black.withValues(alpha: 0.1),
-        body: AnimatedBuilder(
-            animation: _controller,
-            builder: (context, child) {
-              return InteractiveViewer(
-                child: Stack(
-                  children: [
-                    Positioned.directional(
-                      textDirection: Directionality.of(context),
-                      start: _positionTween.value.dx,
-                      top: _positionTween.value.dy,
-                      child: Container(
-                        clipBehavior: Clip.antiAlias,
-                        width: _sizeTween.value.dx,
-                        height: _sizeTween.value.dy,
-                        decoration: const BoxDecoration(shape: BoxShape.circle),
-                        child: Image(
-                          fit: BoxFit.cover,
-                          image: imageTypeAdapeter(widget.type, widget.image),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              );
-            }),
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: GestureDetector(
+        onTap: () => Navigator.pop(context),
+        child: Center(
+          child: Hero(
+            tag: tag,
+            child: InteractiveViewer(
+              child: Image(image: imageProvider, fit: BoxFit.contain),
+            ),
+          ),
+        ),
       ),
     );
   }
 }
+
+enum CImageType { Asset, Network, File, Memory }


### PR DESCRIPTION
## Summary
- add a reusable fade+scale page route
- rework custom hero widget to use the new route and built-in Hero

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846af6271188328bb800f8e77c83562