### PR TITLE
Remove hero animations from item cards

### DIFF
--- a/lib/ui/screens/ad_details_screen.dart
+++ b/lib/ui/screens/ad_details_screen.dart
@@ -1741,9 +1741,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
 
 //ImageView
   Widget setImageViewer() {
-    return Hero(
-      tag: 'item_\${model.id}',
-      child: Container(
+    return Container(
         height: 369,
         decoration: BoxDecoration(borderRadius: BorderRadius.circular(18)),
         padding: const EdgeInsets.symmetric(vertical: 10),

--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -749,14 +749,11 @@ class _ItemCardState extends State<ItemCard> {
                 // IMAGE
                 ClipRRect(
                   borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-                  child: Hero(
-                    tag: 'item_\${widget.item?.id}',
-                    child: UiUtils.getImage(
-                      widget.item?.image ?? "",
-                      height: imageHeight,
-                      width: double.infinity,
-                      fit: BoxFit.cover,
-                    ),
+                  child: UiUtils.getImage(
+                    widget.item?.image ?? "",
+                    height: imageHeight,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
                   ),
                 ),
 

--- a/lib/ui/screens/home/widgets/item_horizontal_card.dart
+++ b/lib/ui/screens/home/widgets/item_horizontal_card.dart
@@ -163,16 +163,13 @@ class ItemHorizontalCard extends StatelessWidget {
                         children: [
                           Stack(
                             children: [
-                              Hero(
-                                tag: 'item_\${item.id}',
-                                child: ClipRRect(
-                                  borderRadius: BorderRadius.circular(borderRadius),
-                                  child: UiUtils.getImage(
-                                    item.image ?? "",
-                                    height: imageHeight,
-                                    width: imageWidth + (additionalImageWidth ?? 0),
-                                    fit: BoxFit.cover,
-                                  ),
+                              ClipRRect(
+                                borderRadius: BorderRadius.circular(borderRadius),
+                                child: UiUtils.getImage(
+                                  item.image ?? "",
+                                  height: imageHeight,
+                                  width: imageWidth + (additionalImageWidth ?? 0),
+                                  fit: BoxFit.cover,
                                 ),
                               ),
                               if (item.isFeature ?? false)


### PR DESCRIPTION
## Summary
- eliminate `Hero` wrappers from item image widgets
- revert to simple image containers

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b7b69c748328b76af9d047a2b591