### PR TITLE
Implement card field display

### DIFF
--- a/lib/data/model/item/item_card_field.dart
+++ b/lib/data/model/item/item_card_field.dart
@@ -1,0 +1,28 @@
+class ItemCardField {
+  final String? name;
+  final String? icon;
+  final String? value;
+
+  ItemCardField({this.name, this.icon, this.value});
+
+  factory ItemCardField.fromJson(Map<String, dynamic> json) {
+    return ItemCardField(
+      name: json['name'],
+      icon: json['icon'],
+      value: json['value']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'icon': icon,
+      'value': value,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'ItemCardField(name: \$name, icon: \$icon, value: \$value)';
+  }
+}

--- a/lib/data/model/item/item_model.dart
+++ b/lib/data/model/item/item_model.dart
@@ -1,6 +1,7 @@
 import 'package:Talab/data/model/category_model.dart';
 import 'package:Talab/data/model/custom_field/custom_field_model.dart';
 import 'package:Talab/data/model/seller_ratings_model.dart';
+import 'package:Talab/data/model/item/item_card_field.dart';
 
 class ItemModel {
   int? id;
@@ -25,6 +26,7 @@ class ItemModel {
   User? user;
   List<GalleryImages>? galleryImages;
   List<ItemOffers>? itemOffers;
+  List<ItemCardField>? cardFields;
   CategoryModel? category;
   List<CustomFieldModel>? customFields;
   bool? isLike;
@@ -94,6 +96,7 @@ class ItemModel {
       this.user,
       this.galleryImages,
       this.itemOffers,
+      this.cardFields,
       this.customFields,
       this.isLike,
       this.isFeature,
@@ -140,6 +143,7 @@ class ItemModel {
       User? user,
       List<GalleryImages>? galleryImages,
       List<ItemOffers>? itemOffers,
+      List<ItemCardField>? cardFields,
       CategoryModel? category,
       List<CustomFieldModel>? customFields,
       bool? isLike,
@@ -183,6 +187,7 @@ class ItemModel {
       user: user ?? this.user,
       galleryImages: galleryImages ?? this.galleryImages,
       itemOffers: itemOffers ?? this.itemOffers,
+      cardFields: cardFields ?? this.cardFields,
       customFields: customFields ?? this.customFields,
       isLike: isLike ?? this.isLike,
       isFeature: isFeature ?? this.isFeature,
@@ -286,6 +291,12 @@ language = json['language'];
         customFields!.add(CustomFieldModel.fromMap(v));
       });
     }
+    if (json['card_fields'] != null) {
+      cardFields = <ItemCardField>[];
+      for (var v in json['card_fields']) {
+        cardFields!.add(ItemCardField.fromJson(v));
+      }
+    }
   }
 
   Map<String, dynamic> toJson() {
@@ -345,12 +356,15 @@ language = json['language'];
     if (customFields != null) {
       data['custom_fields'] = customFields!.map((v) => v.toMap()).toList();
     }
+    if (cardFields != null) {
+      data['card_fields'] = cardFields!.map((v) => v.toJson()).toList();
+    }
     return data;
   }
 
   @override
   String toString() {
-    return 'ItemModel{id: $id, name: $name,slug:$slug, description: $description, price: $price, image: $image, watermarkimage: $watermarkimage, latitude: $latitude, longitude: $longitude, address: $address, contact: $contact, total_likes: $totalLikes,isLiked: $isLike, isFeature: $isFeature,views: $views, type: $type, status: $status, active: $active, videoLink: $videoLink, user: $user, galleryImages: $galleryImages,itemOffers:$itemOffers, category: $category, customFields: $customFields,createdAt:$created,itemType:$itemType,userId:$userId,categoryId:$categoryId,isAlreadyOffered:$isAlreadyOffered,isAlreadyReported:$isAlreadyReported,allCategoryId:$allCategoryIds,rejected_reason:$rejectedReason,area_id:$areaId,area:$area,city:$city,state:$state,country:$country,is_purchased:$isPurchased,review:$review}';
+    return 'ItemModel{id: $id, name: $name,slug:$slug, description: $description, price: $price, image: $image, watermarkimage: $watermarkimage, latitude: $latitude, longitude: $longitude, address: $address, contact: $contact, total_likes: $totalLikes,isLiked: $isLike, isFeature: $isFeature,views: $views, type: $type, status: $status, active: $active, videoLink: $videoLink, user: $user, galleryImages: $galleryImages,itemOffers:$itemOffers, cardFields:$cardFields, category: $category, customFields: $customFields,createdAt:$created,itemType:$itemType,userId:$userId,categoryId:$categoryId,isAlreadyOffered:$isAlreadyOffered,isAlreadyReported:$isAlreadyReported,allCategoryId:$allCategoryIds,rejected_reason:$rejectedReason,area_id:$areaId,area:$area,city:$city,state:$state,country:$country,is_purchased:$isPurchased,review:$review}';
   }
 }
 

--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -16,6 +16,7 @@ import 'package:Talab/utils/custom_text.dart';
 import 'package:Talab/utils/extensions/extensions.dart';
 import 'package:Talab/utils/extensions/lib/currency_formatter.dart';
 import 'package:Talab/utils/ui_utils.dart';
+import 'package:Talab/utils/icon_mapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:carousel_slider/carousel_slider.dart';
@@ -783,8 +784,8 @@ class _ItemCardState extends State<ItemCard> {
                         ),
                       ),
                       if ((widget.item?.address ?? "").isNotEmpty) ...[
-                        const SizedBox(height: 2),
-                        Row(
+                      const SizedBox(height: 2),
+                      Row(
                           children: [
                             UiUtils.getSvg(AppIcons.location, width: 12, height: 12),
                             const SizedBox(width: 4),
@@ -797,6 +798,18 @@ class _ItemCardState extends State<ItemCard> {
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),
+                          ],
+                        ),
+                      ],
+                      if (widget.item?.cardFields != null && widget.item!.cardFields!.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Row(
+                          children: [
+                            _buildCardField(widget.item!.cardFields![0]),
+                            if (widget.item!.cardFields!.length > 1) ...[
+                              const SizedBox(width: 8),
+                              _buildCardField(widget.item!.cardFields![1]),
+                            ]
                           ],
                         ),
                       ],
@@ -816,6 +829,29 @@ class _ItemCardState extends State<ItemCard> {
       ),
     );
   }
+  Widget _buildCardField(ItemCardField field) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          IconMapper.map(field.icon),
+          size: 14,
+          color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+        ),
+        const SizedBox(width: 2),
+        Flexible(
+          child: CustomText(
+            field.value ?? ''  
+            fontSize: context.font.smaller,
+            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+
 
   
 

--- a/lib/ui/screens/home/widgets/item_horizontal_card.dart
+++ b/lib/ui/screens/home/widgets/item_horizontal_card.dart
@@ -13,6 +13,7 @@ import 'package:Talab/utils/custom_text.dart';
 import 'package:Talab/utils/extensions/extensions.dart';
 import 'package:Talab/utils/extensions/lib/currency_formatter.dart';
 import 'package:Talab/utils/ui_utils.dart';
+import 'package:Talab/utils/icon_mapper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -248,6 +249,19 @@ class ItemHorizontalCard extends StatelessWidget {
                                     ))
                                   ],
                                 )
+                              if (item.cardFields != null && item.cardFields!.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 2.0),
+                                  child: Row(
+                                    children: [
+                                      _buildCardField(context, item.cardFields![0], iconSize, fontSizeAddress),
+                                      if (item.cardFields!.length > 1) ...[
+                                        const SizedBox(width: 8),
+                                        _buildCardField(context, item.cardFields![1], iconSize, fontSizeAddress),
+                                      ]
+                                    ],
+                                  ),
+                                ),
                             ],
                           ),
                         ),
@@ -263,7 +277,17 @@ class ItemHorizontalCard extends StatelessWidget {
         ),
       ),
     );
+  Widget _buildCardField(BuildContext context, ItemCardField field, double iconSize, double fontSize) {
+      return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(IconMapper.map(field.icon), size: iconSize, color: context.color.textDefaultColor.withOpacity(0.5)),
+        const SizedBox(width: 2),
+        Flexible(child: CustomText(field.value ?? '', fontSize: fontSize, color: context.color.textDefaultColor.withOpacity(0.5), maxLines: 1, overflow: TextOverflow.ellipsis)),
+      ],
+    );
   }
+
 }
 
 class StatusButton {

--- a/lib/utils/icon_mapper.dart
+++ b/lib/utils/icon_mapper.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class IconMapper {
+  static const Map<String, IconData> _iconMap = {
+    'home': Icons.home,
+    'bed': Icons.bed,
+    'bedroom': Icons.bed,
+    'bath': Icons.bathtub,
+    'bathroom': Icons.bathtub,
+    'area': Icons.square_foot,
+    'garage': Icons.garage,
+    'calendar': Icons.calendar_today,
+    'clock': Icons.access_time,
+    'phone': Icons.phone,
+    'email': Icons.email,
+    'location': Icons.location_on,
+    'star': Icons.star,
+  };
+
+  static IconData map(String? iconName) {
+    if (iconName == null) return Icons.info_outline;
+    return _iconMap[iconName] ?? Icons.info_outline;
+  }
+}


### PR DESCRIPTION
## Summary
- parse `card_fields` in `ItemModel`
- add `ItemCardField` model
- show card field values in item cards and horizontal cards
- provide material icon mapping utility

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684923143a80832891826cef76fd3084