### PR TITLE
Fix CustomText call in home sections adapter

### DIFF
--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -841,7 +841,7 @@ class _ItemCardState extends State<ItemCard> {
         const SizedBox(width: 2),
         Flexible(
           child: CustomText(
-            field.value ?? ''  
+            field.value ?? '',
             fontSize: context.font.smaller,
             color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
             maxLines: 1,


### PR DESCRIPTION
## Summary
- fix missing comma in `_buildCardField` so `CustomText` is valid

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684931cec60483288ac97db7307507b8