### PR TITLE
Add banner slider to subcategory screen

### DIFF
--- a/lib/app/register_cubits.dart
+++ b/lib/app/register_cubits.dart
@@ -67,6 +67,7 @@ import 'package:Talab/data/cubits/system/language_cubit.dart';
 import 'package:Talab/data/cubits/system/notification_cubit.dart';
 import 'package:Talab/data/cubits/system/user_details.dart';
 import 'package:Talab/data/cubits/utility/item_edit_global.dart';
+import 'package:Talab/data/cubits/banner_cubit.dart';
 import 'package:Talab/data/repositories/favourites_repository.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nested/nested.dart';
@@ -79,6 +80,7 @@ class RegisterCubits {
     BlocProvider(create: (context) => AuthCubit()),
     BlocProvider(create: (context) => LoginCubit()),
     BlocProvider(create: (context) => SliderCubit()),
+    BlocProvider(create: (context) => BannerCubit()),
     BlocProvider(create: (context) => CompanyCubit()),
     BlocProvider(create: (context) => FetchCategoryCubit()),
     BlocProvider(create: (context) => ProfileSettingCubit()),

--- a/lib/data/cubits/banner_cubit.dart
+++ b/lib/data/cubits/banner_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../model/banner_model.dart';
+import '../repositories/banner_repository.dart';
+
+abstract class BannerState {}
+
+class BannerInitial extends BannerState {}
+
+class BannerLoading extends BannerState {}
+
+class BannerSuccess extends BannerState {
+  final List<BannerModel> banners;
+  BannerSuccess(this.banners);
+}
+
+class BannerFailure extends BannerState {
+  final dynamic error;
+  BannerFailure(this.error);
+}
+
+class BannerCubit extends Cubit<BannerState> {
+  BannerCubit() : super(BannerInitial());
+  final BannerRepository _repository = BannerRepository();
+
+  Future<void> fetchBanners({int? categoryId}) async {
+    emit(BannerLoading());
+    try {
+      final data = await _repository.fetchBanners(categoryId: categoryId);
+      emit(BannerSuccess(data));
+    } catch (e) {
+      emit(BannerFailure(e));
+    }
+  }
+}

--- a/lib/data/model/banner_model.dart
+++ b/lib/data/model/banner_model.dart
@@ -1,0 +1,29 @@
+class BannerModel {
+  final int? id;
+  final String? image;
+  final String? linkType;
+  final String? linkTarget;
+  final int? sequence;
+
+  BannerModel({this.id, this.image, this.linkType, this.linkTarget, this.sequence});
+
+  factory BannerModel.fromJson(Map<String, dynamic> json) {
+    return BannerModel(
+      id: json['id'] is String ? int.tryParse(json['id'].toString()) : json['id'],
+      image: json['image'] as String?,
+      linkType: json['link_type'] as String?,
+      linkTarget: json['link_target']?.toString(),
+      sequence: json['sequence'] is String ? int.tryParse(json['sequence'].toString()) : json['sequence'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'image': image,
+      'link_type': linkType,
+      'link_target': linkTarget,
+      'sequence': sequence,
+    };
+  }
+}

--- a/lib/data/repositories/banner_repository.dart
+++ b/lib/data/repositories/banner_repository.dart
@@ -1,0 +1,22 @@
+import 'package:Talab/data/model/banner_model.dart';
+import 'package:Talab/utils/api.dart';
+
+class BannerRepository {
+  Future<List<BannerModel>> fetchBanners({int? categoryId}) async {
+    try {
+      final resp = await Api.get(
+        url: Api.getBannersApi,
+        queryParameters:
+            categoryId == null ? null : {'category_id': categoryId},
+      );
+      final list = (resp['data'] as List?)
+              ?.map((e) => BannerModel.fromJson(e))
+              .toList() ??
+          [];
+      list.sort((a, b) => (a.sequence ?? 0).compareTo(b.sequence ?? 0));
+      return list;
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/ui/screens/sub_category/sub_category_screen.dart
+++ b/lib/ui/screens/sub_category/sub_category_screen.dart
@@ -10,6 +10,8 @@ import 'package:Talab/utils/api.dart';
 import 'package:Talab/utils/custom_text.dart';
 import 'package:Talab/utils/extensions/extensions.dart';
 import 'package:Talab/utils/ui_utils.dart';
+import 'package:Talab/data/cubits/banner_cubit.dart';
+import 'package:Talab/ui/screens/sub_category/subcategory_banner_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shimmer/shimmer.dart';
@@ -118,6 +120,11 @@ class _CategoryListState extends State<SubCategoryScreen>
                             });
                       },
                     ),
+                    const Divider(
+                      thickness: 1.2,
+                      height: 10,
+                    ),
+                    SubCategoryBannerSlider(categoryId: widget.catId),
                     const Divider(
                       thickness: 1.2,
                       height: 10,

--- a/lib/ui/screens/sub_category/subcategory_banner_slider.dart
+++ b/lib/ui/screens/sub_category/subcategory_banner_slider.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:Talab/app/routes.dart';
+import 'package:Talab/data/cubits/banner_cubit.dart';
+import 'package:Talab/data/model/banner_model.dart';
+import 'package:Talab/data/model/data_output.dart';
+import 'package:Talab/data/model/item/item_model.dart';
+import 'package:Talab/data/repositories/item/item_repository.dart';
+import 'package:Talab/utils/helper_utils.dart';
+import 'package:Talab/ui/theme/theme.dart';
+import 'package:Talab/data/helper/widgets.dart';
+
+class SubCategoryBannerSlider extends StatefulWidget {
+  final int categoryId;
+  const SubCategoryBannerSlider({super.key, required this.categoryId});
+
+  @override
+  State<SubCategoryBannerSlider> createState() => _SubCategoryBannerSliderState();
+}
+
+class _SubCategoryBannerSliderState extends State<SubCategoryBannerSlider>
+    with AutomaticKeepAliveClientMixin {
+  late PageController _controller;
+  Timer? _timer;
+  int _current = 0;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  bool _isTablet(BuildContext ctx) => MediaQuery.of(ctx).size.shortestSide >= 600;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PageController(viewportFraction: 0.90, initialPage: 0);
+    context.read<BannerCubit>().fetchBanners(categoryId: widget.categoryId);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _startAutoSlide(int count) {
+    if (count <= 1) return;
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 5), (_) {
+      if (_controller.hasClients) {
+        if (_current < count - 1) {
+          _controller.nextPage(duration: const Duration(milliseconds: 600), curve: Curves.easeInOutQuint);
+        } else {
+          _controller.animateToPage(0, duration: const Duration(milliseconds: 600), curve: Curves.easeInOutQuint);
+        }
+      }
+    });
+  }
+
+  double _sliderHeight(BuildContext ctx) {
+    final size = MediaQuery.of(ctx).size;
+    if (_isTablet(ctx)) return math.min(420, size.height * 0.28);
+    return size.height * 0.35;
+  }
+
+  double _dotSize(BuildContext ctx) => _isTablet(ctx) ? 10.0 : MediaQuery.of(ctx).size.width * 0.025;
+
+  Widget _buildDotIndicator(int total) {
+    final dot = _dotSize(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(total, (i) {
+        return Container(
+          width: dot,
+          height: dot,
+          margin: EdgeInsets.symmetric(horizontal: dot * .4),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: i == _current ? Theme.of(context).primaryColor : Colors.grey.shade300,
+          ),
+        );
+      }),
+    );
+  }
+
+  Future<void> _onBannerTap(BannerModel banner) async {
+    final type = banner.linkType;
+    final target = banner.linkTarget;
+    try {
+      if (type == 'custom_url' && target != null) {
+        await launchUrl(Uri.parse(target), mode: LaunchMode.externalApplication);
+      } else if (type == 'create_ad') {
+        Navigator.pushNamed(context, Routes.selectCategoryScreen);
+      } else if (type == 'category' && target != null) {
+        Navigator.pushNamed(context, Routes.subCategoryScreen, arguments: {
+          'categoryList': <dynamic>[],
+          'catName': '',
+          'catId': int.tryParse(target) ?? 0,
+          'categoryIds': [target]
+        });
+      } else if (type == 'item' && target != null) {
+        try {
+          Widgets.showLoader(context);
+          final repo = ItemRepository();
+          final DataOutput<ItemModel> data = await repo.fetchItemFromItemId(int.parse(target));
+          Widgets.hideLoder(context);
+          Navigator.pushNamed(context, Routes.adDetailsScreen, arguments: {'model': data.modelList.first});
+        } catch (e) {
+          Widgets.hideLoder(context);
+          HelperUtils.showSnackBarMessage(context, e.toString());
+        }
+      }
+    } catch (e) {
+      HelperUtils.showSnackBarMessage(context, e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final h = MediaQuery.of(context).size.height;
+    final w = MediaQuery.of(context).size.width;
+
+    return BlocConsumer<BannerCubit, BannerState>(
+      listener: (_, state) {
+        if (state is BannerSuccess) _startAutoSlide(state.banners.length);
+      },
+      builder: (ctx, state) {
+        if (state is BannerSuccess && state.banners.isNotEmpty) {
+          final banners = state.banners;
+          Widget pageView() => PageView.builder(
+                controller: _controller,
+                clipBehavior: Clip.none,
+                itemCount: banners.length,
+                physics: const BouncingScrollPhysics(),
+                onPageChanged: (i) => setState(() => _current = i),
+                itemBuilder: (ctx, i) {
+                  return AnimatedBuilder(
+                    animation: _controller,
+                    builder: (ctx, child) {
+                      double v = 0;
+                      if (_controller.position.haveDimensions) {
+                        v = i - (_controller.page ?? 0);
+                        v = (v * 0.05).clamp(-1, 1);
+                      }
+                      return Transform(
+                        transform: Matrix4.identity()
+                          ..setEntry(3, 2, 0.002)
+                          ..rotateY(math.pi * v * 0.5)
+                          ..scale(1 - v.abs() * 0.1),
+                        alignment: Alignment.center,
+                        child: GestureDetector(
+                          onTap: () => _onBannerTap(banners[i]),
+                          child: Container(
+                            margin: EdgeInsets.symmetric(horizontal: w * 0.015),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(w * 0.05),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.15 + v.abs() * 0.05),
+                                  blurRadius: w * 0.03,
+                                  spreadRadius: w * 0.005,
+                                  offset: Offset(0, w * 0.015),
+                                ),
+                              ],
+                            ),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(w * 0.05),
+                              child: Transform.translate(
+                                offset: Offset(v * 20, 0),
+                                child: CachedNetworkImage(
+                                  imageUrl: banners[i].image ?? '',
+                                  fit: BoxFit.contain,
+                                  placeholder: (_, __) => const Center(child: CircularProgressIndicator(color: Colors.white70)),
+                                  errorWidget: (_, __, ___) => const Icon(Icons.error, color: Colors.redAccent, size: 40),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              );
+
+          return Column(
+            children: [
+              _isTablet(context)
+                  ? SizedBox(height: _sliderHeight(context), child: pageView())
+                  : AspectRatio(aspectRatio: 16 / 9, child: SizedBox(height: h * 0.35, child: pageView())),
+              SizedBox(height: h * 0.025),
+              _buildDotIndicator(banners.length),
+            ],
+          );
+        } else if (state is BannerLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -68,6 +68,7 @@ class Api {
   static String loginApi = "user-signup";
   static String updateProfileApi = "update-profile";
   static String getSliderApi = "get-slider";
+  static String getBannersApi = "banners";
   static String getCategoriesApi = "get-categories";
   static String getItemApi = "get-item";
   static String getMyItemApi = "my-items";


### PR DESCRIPTION
## Summary
- support `/api/banners` endpoint
- model and cubit for banners
- repository for banner API
- slider widget for subcategory banners
- show banner slider in subcategory screen
- register `BannerCubit`
- fetch banners for specific category

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a89697ebc8328b502bfb4542aa751