### PR TITLE
Improve tablet grid layout

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -592,7 +592,7 @@ class AllItemsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final crossCount = MediaQuery.of(context).size.width > 600 ? 3 : 2;
+    final crossCount = MediaQuery.of(context).size.width > 600 ? 4 : 2;
     const spacing  = 12.0;
 
     return Column(

--- a/lib/ui/screens/item/items_list.dart
+++ b/lib/ui/screens/item/items_list.dart
@@ -61,6 +61,9 @@ class ItemsListState extends State<ItemsList> {
   ItemFilterModel? filter;
   static const double searchBarHeight = 56.0;
 
+  bool _isTablet(BuildContext context) =>
+      MediaQuery.of(context).size.shortestSide >= 600;
+
   @override
   void initState() {
     super.initState();
@@ -734,6 +737,28 @@ class ItemsListState extends State<ItemsList> {
 
   Widget _buildListViewSection(BuildContext context, int startIndex,
       int itemCount, List<ItemModel> items) {
+    if (_isTablet(context)) {
+      return GridView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight(
+          crossAxisCount: 2,
+          height: MediaQuery.of(context).size.height / 4.5,
+          mainAxisSpacing: 7,
+          crossAxisSpacing: 10,
+        ),
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          ItemModel item = items[startIndex + index];
+          return GestureDetector(
+            onTap: () => _navigateToDetails(context, item),
+            child: ItemHorizontalCard(item: item),
+          );
+        },
+      );
+    }
+
     return ListView.builder(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
@@ -756,7 +781,7 @@ class ItemsListState extends State<ItemsList> {
       physics: const NeverScrollableScrollPhysics(),
       padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 5),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight(
-          crossAxisCount: 2,
+          crossAxisCount: _isTablet(context) ? 4 : 2,
           height: MediaQuery.of(context).size.height / 3.5,
           mainAxisSpacing: 7,
           crossAxisSpacing: 10),


### PR DESCRIPTION
## Summary
- tweak category items grid for tablets with 4 columns
- use 2-column card layout on tablets
- show four columns on All Items widget for wide displays

## Testing
- `flutter format lib/ui/screens/item/items_list.dart lib/ui/screens/home/home_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c22c1e574832897a2350069c87225