### PR TITLE
Adjust tablet grid layout for home categories

### DIFF
--- a/lib/ui/screens/home/category_list.dart
+++ b/lib/ui/screens/home/category_list.dart
@@ -101,8 +101,13 @@ class _CategoryListState extends State<CategoryList> {
                               shrinkWrap: true,
                               physics: const NeverScrollableScrollPhysics(),
                               gridDelegate:
-                                  const SliverSimpleGridDelegateWithFixedCrossAxisCount(
-                                crossAxisCount: 2,
+                                  SliverSimpleGridDelegateWithFixedCrossAxisCount(
+                                crossAxisCount: MediaQuery.of(context).size.width >= 600 &&
+                                        MediaQuery.of(context).size.width <= 1200
+                                    ? 3
+                                    : MediaQuery.of(context).size.width > 1200
+                                        ? 4
+                                        : 2,
                               ),
                               itemCount: category.children?.length ?? 0,
                               itemBuilder: (context, subIndex) {


### PR DESCRIPTION
## Summary
- tweak category grid to display three subcategories per row on tablet

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c244945288328a22dd0ed877542b8