### PR TITLE
Fix theme color mismatches

### DIFF
--- a/lib/ui/screens/home/category_list.dart
+++ b/lib/ui/screens/home/category_list.dart
@@ -59,7 +59,7 @@ class _CategoryListState extends State<CategoryList> {
                           horizontal: 15, vertical: 12),
                       margin: const EdgeInsets.symmetric(vertical: 5),
                       decoration: BoxDecoration(
-                        color: Colors.blue.shade100,
+                        color: context.color.secondaryColor.withOpacity(0.1),
                         borderRadius: BorderRadius.circular(10),
                         boxShadow: [
                           BoxShadow(
@@ -83,7 +83,7 @@ class _CategoryListState extends State<CategoryList> {
                             _expandedCategories[category.id!] ?? false
                                 ? Icons.keyboard_arrow_up
                                 : Icons.keyboard_arrow_down,
-                            color: Colors.blue.shade900,
+                            color: context.color.textDefaultColor,
                           ),
                         ],
                       ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -204,9 +204,11 @@ class HomeScreenState extends State<HomeScreen>
                   ContactUs.route(const RouteSettings(name: '/contact-us')),
                 );
               },
-              label:
-                  const Text('Customer Support', style: TextStyle(color: Colors.black)),
-              icon: const Icon(Icons.headset_mic_outlined, color: Colors.black),
+              style: TextButton.styleFrom(
+                foregroundColor: context.color.textDefaultColor,
+              ),
+              label: const Text('Customer Support'),
+              icon: const Icon(Icons.headset_mic_outlined),
             ),
           ],
         ),
@@ -546,7 +548,7 @@ class AllItemsWidget extends StatelessWidget {
           style: TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.bold,
-            color: Colors.black87,
+            color: context.color.textDefaultColor,
           ),
         ),
       ),

--- a/lib/ui/screens/home/widgets/category_widget_home.dart
+++ b/lib/ui/screens/home/widgets/category_widget_home.dart
@@ -376,7 +376,7 @@ class _AccordionGrid extends StatelessWidget {
                       vertical: containerPaddingVertical),
                   margin: EdgeInsets.only(bottom: marginBottom),
                   decoration: BoxDecoration(
-                    color: Colors.blue.shade100,
+                    color: context.color.secondaryColor.withOpacity(0.1),
                     borderRadius: BorderRadius.circular(borderRadius),
                     boxShadow: [
                       BoxShadow(
@@ -399,7 +399,7 @@ class _AccordionGrid extends StatelessWidget {
                         isOpen
                             ? Icons.keyboard_arrow_up
                             : Icons.keyboard_arrow_down,
-                        color: Colors.blue.shade900,
+                        color: context.color.textDefaultColor,
                         size: iconSize,
                       ),
                     ],

--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -130,7 +130,7 @@ class HomeSectionsAdapter extends StatelessWidget {
                             style: TextStyle(
                               fontSize: 13,
                               fontWeight: FontWeight.w700,
-                              color: Colors.black87,
+                              color: context.color.textDefaultColor,
                             ),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
@@ -144,24 +144,24 @@ class HomeSectionsAdapter extends StatelessWidget {
                                 style: TextStyle(
                                   fontSize: 12,
                                   fontWeight: FontWeight.bold,
-                                  color: Colors.blueAccent,
+                                  color: context.color.territoryColor,
                                 ),
                               ),
                               Container(
                                 padding: EdgeInsets.symmetric(horizontal: 5, vertical: 1),
                                 decoration: BoxDecoration(
-                                  color: Colors.blueAccent.withOpacity(0.1),
+                                  color: context.color.territoryColor.withOpacity(0.1),
                                   borderRadius: BorderRadius.circular(8),
                                 ),
                                 child: Row(
                                   children: [
-                                    Icon(Icons.star, size: 11, color: Colors.blueAccent),
+                                    Icon(Icons.star, size: 11, color: context.color.territoryColor),
                                     SizedBox(width: 1),
                                     Text(
                                       "4.8",
                                       style: TextStyle(
                                         fontSize: 9,
-                                        color: Colors.blueAccent,
+                                        color: context.color.territoryColor,
                                         fontWeight: FontWeight.w600,
                                       ),
                                     ),

--- a/lib/ui/screens/settings/contact_us.dart
+++ b/lib/ui/screens/settings/contact_us.dart
@@ -42,12 +42,12 @@ class ContactUsState extends State<ContactUs> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Color(0xFFE3F2FD),
+      backgroundColor: context.color.backgroundColor,
       appBar: AppBar(
-        backgroundColor: Color(0xFF42A5F5),
-        title: Text('Support', style: TextStyle(color: Colors.white)),
+        backgroundColor: context.color.secondaryColor,
+        title: Text('Support', style: TextStyle(color: context.color.textDefaultColor)),
         leading: IconButton(
-          icon: Icon(Icons.arrow_back, color: Colors.white),
+          icon: Icon(Icons.arrow_back, color: context.color.textDefaultColor),
           onPressed: () => Navigator.pop(context),
         ),
       ),
@@ -62,7 +62,7 @@ class ContactUsState extends State<ContactUs> {
               child: Container(
                 padding: const EdgeInsets.symmetric(vertical: 16.0),
                 child: ListTile(
-                  leading: Icon(Icons.email, color: Color(0xFF42A5F5)),
+                  leading: Icon(Icons.email, color: context.color.territoryColor),
                   title: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -70,7 +70,7 @@ class ContactUsState extends State<ContactUs> {
                       SizedBox(height: 4),
                       GestureDetector(
                         onTap: () => _launchEmail('support@talab.qa', context),
-                        child: Text('support@talab.qa', style: TextStyle(color: Colors.black87)),
+                        child: Text('support@talab.qa', style: TextStyle(color: context.color.textDefaultColor)),
                       ),
                     ],
                   ),
@@ -82,9 +82,9 @@ class ContactUsState extends State<ContactUs> {
               elevation: 2,
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
               child: ListTile(
-                leading: Icon(Icons.phone, color: Color(0xFF42A5F5)),
+                leading: Icon(Icons.phone, color: context.color.territoryColor),
                 title: Text('Hotline', style: TextStyle(fontWeight: FontWeight.bold)),
-                subtitle: Text('+974 7061 6051', style: TextStyle(color: Colors.black87)),
+                subtitle: Text('+974 7061 6051', style: TextStyle(color: context.color.textDefaultColor)),
                 trailing: GestureDetector(
                   onTap: () => _launchWhatsApp('+97470616051'),
                   child: Row(
@@ -94,14 +94,14 @@ class ContactUsState extends State<ContactUs> {
                         AppIcons.whatsappPng,
                         width: 20,
                         height: 20,
-                        color: Color(0xFF42A5F5),
+                        color: context.color.territoryColor,
                       ),
                       SizedBox(width: 5),
                       Text(
                         'Chat',
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
-                          color: Colors.black87,
+                          color: context.color.textDefaultColor,
                         ),
                       ),
                     ],
@@ -115,9 +115,9 @@ class ContactUsState extends State<ContactUs> {
               elevation: 2,
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
               child: ListTile(
-                leading: Icon(Icons.language, color: Color(0xFF42A5F5)),
+                leading: Icon(Icons.language, color: context.color.territoryColor),
                 title: Text('Website', style: TextStyle(fontWeight: FontWeight.bold)),
-                subtitle: Text('talab.qa', style: TextStyle(color: Colors.black87)),
+                subtitle: Text('talab.qa', style: TextStyle(color: context.color.textDefaultColor)),
                 onTap: () => _launchURL('https://talab.qa', context),
               ),
             ),


### PR DESCRIPTION
## Summary
- ensure buttons and icons use theme colors
- unify category card colors with theme
- update contact page colors for dark mode compatibility
- apply theme color to text and badges in item sections

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1afe24048328a90c95fb6f4a0739