### PR TITLE
Implement masonry grid for item cards

### DIFF
--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -418,7 +418,6 @@ class ItemCard extends StatefulWidget {
 
 class _ItemCardState extends State<ItemCard> {
   final double likeButtonSize = 32;
-  final double imageHeight    = 165;
 
   @override
   void initState() {
@@ -452,14 +451,23 @@ class _ItemCardState extends State<ItemCard> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // IMAGE
-                ClipRRect(
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-                  child: UiUtils.getImage(
-                    widget.item?.image ?? "",
-                    height: imageHeight,
-                    width: double.infinity,
-                    fit: BoxFit.cover,
-                  ),
+                Stack(
+                  children: [
+                    ClipRRect(
+                      borderRadius:
+                          const BorderRadius.vertical(top: Radius.circular(16)),
+                      child: UiUtils.getImage(
+                        widget.item?.image ?? '',
+                        width: double.infinity,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                    PositionedDirectional(
+                      top: 8,
+                      end: 8,
+                      child: favButton(),
+                    ),
+                  ],
                 ),
 
          
@@ -516,10 +524,6 @@ class _ItemCardState extends State<ItemCard> {
               
               ],
             ),
-
-            // FAVORITE BUTTON
-             favButton(),
-          
           ],
         ),
       ),
@@ -627,52 +631,48 @@ class _ItemCardState extends State<ItemCard> {
                   }),
 
                   builder: (context, state) {
-                    return PositionedDirectional(
-                      top: imageHeight - (likeButtonSize / 2) - 2,
-                      end: 16,
-                      child: InkWell(
-                        onTap: () {
-                          UiUtils.checkUser(
-                              onNotGuest: () {
-                                context
-                                    .read<UpdateFavoriteCubit>()
-                                    .setFavoriteItem(
-                                      item: widget.item!,
-                                      type: isLike ? 0 : 1,
-                                    );
-                              },
-                              context: context);
-                        },
-                        child: Container(
-                          width: likeButtonSize,
-                          height: likeButtonSize,
-                          decoration: BoxDecoration(
-                            color: context.color.secondaryColor,
-                            shape: BoxShape.circle,
-                            boxShadow:
-                                context.watch<AppThemeCubit>().state.appTheme ==
-                                        AppTheme.dark
-                                    ? null
-                                    : [
-                                        BoxShadow(
-                                          color: Colors.grey[300]!,
-                                          offset: const Offset(0, 2),
-                                          spreadRadius: 2,
-                                          blurRadius: 4,
-                                        ),
-                                      ],
-                          ),
-                          child: FittedBox(
-                            fit: BoxFit.none,
-                            child: state is UpdateFavoriteInProgress
-                                ? Center(child: UiUtils.progress())
-                                : UiUtils.getSvg(
-                                    isLike ? AppIcons.like_fill : AppIcons.like,
-                                    width: 22,
-                                    height: 22,
-                                    color: context.color.territoryColor,
-                                  ),
-                          ),
+                    return InkWell(
+                      onTap: () {
+                        UiUtils.checkUser(
+                            onNotGuest: () {
+                              context
+                                  .read<UpdateFavoriteCubit>()
+                                  .setFavoriteItem(
+                                    item: widget.item!,
+                                    type: isLike ? 0 : 1,
+                                  );
+                            },
+                            context: context);
+                      },
+                      child: Container(
+                        width: likeButtonSize,
+                        height: likeButtonSize,
+                        decoration: BoxDecoration(
+                          color: context.color.secondaryColor,
+                          shape: BoxShape.circle,
+                          boxShadow:
+                              context.watch<AppThemeCubit>().state.appTheme ==
+                                      AppTheme.dark
+                                  ? null
+                                  : [
+                                      BoxShadow(
+                                        color: Colors.grey[300]!,
+                                        offset: const Offset(0, 2),
+                                        spreadRadius: 2,
+                                        blurRadius: 4,
+                                      ),
+                                    ],
+                        ),
+                        child: FittedBox(
+                          fit: BoxFit.none,
+                          child: state is UpdateFavoriteInProgress
+                              ? Center(child: UiUtils.progress())
+                              : UiUtils.getSvg(
+                                  isLike ? AppIcons.like_fill : AppIcons.like,
+                                  width: 22,
+                                  height: 22,
+                                  color: context.color.territoryColor,
+                                ),
                         ),
                       ),
                     );

--- a/lib/ui/screens/item/items_list.dart
+++ b/lib/ui/screens/item/items_list.dart
@@ -924,11 +924,7 @@ class ItemsListState extends State<ItemsList> {
   Widget _buildGridViewSection(BuildContext context, int startIndex,
       int itemCount, List<ItemModel> items) {
     final screenWidth = MediaQuery.of(context).size.width;
-    final crossAxisCount = screenWidth < 600
-        ? 2
-        : screenWidth <= 1200
-            ? 4
-            : 4;
+    final crossAxisCount = screenWidth >= 600 ? 4 : 2;
 
     return MasonryGridView.builder(
       shrinkWrap: true,


### PR DESCRIPTION
## Summary
- show favorite button on top of card image
- remove fixed image height so the card grows naturally
- simplify crossAxisCount logic in item list grid

## Testing
- `flutter pub get` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d4c9f1d308328bca689633fb1909a