### PR TITLE
Fix tablet layout issues

### DIFF
--- a/lib/ui/screens/home/category_list.dart
+++ b/lib/ui/screens/home/category_list.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:Talab/data/cubits/category/fetch_category_cubit.dart';
 import 'package:Talab/utils/ui_utils.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:Talab/data/model/category_model.dart';
 
 class CategoryList extends StatefulWidget {
   const CategoryList({Key? key}) : super(key: key);
@@ -99,87 +100,44 @@ class _CategoryListState extends State<CategoryList> {
                     child: (_expandedCategories[category.id!] ?? false)
                         ? Padding(
                             padding: const EdgeInsets.only(bottom: 15),
-                            child: MasonryGridView.builder(
-                              shrinkWrap: true,
-                              physics: const NeverScrollableScrollPhysics(),
-                              gridDelegate:
-                                  SliverSimpleGridDelegateWithFixedCrossAxisCount(
-                                crossAxisCount: MediaQuery.of(context).size.width >= 600 &&
-                                        MediaQuery.of(context).size.width <= 1200
-                                    ? 3
-                                    : MediaQuery.of(context).size.width > 1200
-                                        ? 4
-                                        : 2,
-                              ),
-                              itemCount: category.children?.length ?? 0,
-                              itemBuilder: (context, subIndex) {
-                                final subCategory = category.children![subIndex];
-
-                                return GestureDetector(
-                                  onTap: () {
-                                    // Handle subcategory click
-                                  },
-                                  child: Container(
-                                    margin: const EdgeInsets.all(6),
-                                    decoration: BoxDecoration(
-                                      borderRadius: BorderRadius.circular(12),
-                                      boxShadow: [
-                                        BoxShadow(
-                                          color: Colors.black.withOpacity(0.1),
-                                          blurRadius: 5,
-                                          offset: const Offset(0, 3),
-                                        ),
-                                      ],
-                                    ),
-                                    child: ClipRRect(
-                                      borderRadius: BorderRadius.circular(12),
-                                      child: Stack(
-                                        children: [
-                                          Image.network(
-                                            subCategory.url!,
-                                            fit: BoxFit.cover,
-                                            height: 120,
-                                            width: double.infinity,
-                                            loadingBuilder:
-                                                (context, child, progress) {
-                                              if (progress == null) {
-                                                return child;
-                                              } else {
-                                                return const Center(
-                                                  child:
-                                                      CircularProgressIndicator(),
-                                                );
-                                              }
-                                            },
-                                          ),
-                                          Positioned(
-                                            bottom: 0,
-                                            left: 0,
-                                            right: 0,
-                                            child: Container(
-                                              padding:
-                                                  const EdgeInsets.symmetric(
-                                                      vertical: 6),
-                                              color: Colors.black
-                                                  .withOpacity(0.6),
-                                              child: Text(
-                                                subCategory.name!,
-                                                textAlign: TextAlign.center,
-                                                style: const TextStyle(
-                                                  color: Colors.white,
-                                                  fontSize: 14,
-                                                  fontWeight: FontWeight.bold,
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
+                            child: Builder(builder: (context) {
+                              final screenWidth = MediaQuery.of(context).size.width;
+                              final isTablet = screenWidth >= 600 && screenWidth <= 1200;
+                              final crossAxisCount = isTablet
+                                  ? 3
+                                  : screenWidth > 1200
+                                      ? 4
+                                      : 2;
+                              if (isTablet) {
+                                return GridView.builder(
+                                  shrinkWrap: true,
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                                    crossAxisCount: 3,
+                                    crossAxisSpacing: 6,
+                                    mainAxisSpacing: 6,
                                   ),
+                                  itemCount: category.children?.length ?? 0,
+                                  itemBuilder: (context, subIndex) {
+                                    final subCategory = category.children![subIndex];
+                                    return _buildSubCategoryItem(subCategory);
+                                  },
                                 );
-                              },
-                            ),
+                              }
+                              return MasonryGridView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                gridDelegate:
+                                    SliverSimpleGridDelegateWithFixedCrossAxisCount(
+                                  crossAxisCount: crossAxisCount,
+                                ),
+                                itemCount: category.children?.length ?? 0,
+                                itemBuilder: (context, subIndex) {
+                                  final subCategory = category.children![subIndex];
+                                  return _buildSubCategoryItem(subCategory);
+                                },
+                              );
+                            }),
                           )
                         : const SizedBox.shrink(),
                   ),
@@ -191,6 +149,65 @@ class _CategoryListState extends State<CategoryList> {
 
         return Container();
       },
+    );
+  }
+
+  Widget _buildSubCategoryItem(CategoryModel subCategory) {
+    return GestureDetector(
+      onTap: () {
+        // Handle subcategory click
+      },
+      child: Container(
+        margin: const EdgeInsets.all(6),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 5,
+              offset: const Offset(0, 3),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: Stack(
+            children: [
+              Image.network(
+                subCategory.url!,
+                fit: BoxFit.cover,
+                height: 120,
+                width: double.infinity,
+                loadingBuilder: (context, child, progress) {
+                  if (progress == null) {
+                    return child;
+                  } else {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                },
+              ),
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  color: Colors.black.withOpacity(0.6),
+                  child: Text(
+                    subCategory.name!,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/screens/home/widgets/category_widget_home.dart
+++ b/lib/ui/screens/home/widgets/category_widget_home.dart
@@ -413,26 +413,107 @@ class _AccordionGrid extends StatelessWidget {
                     ? const SizedBox.shrink()
                     : Padding(
                         padding: EdgeInsets.only(bottom: subPaddingBottom),
-                        child: MasonryGridView.builder(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          gridDelegate:
-                              SliverSimpleGridDelegateWithFixedCrossAxisCount(
-                                  crossAxisCount: crossAxisCount),
-                          itemCount: cat.children?.length ?? 0,
-                          itemBuilder: (_, subIdx) {
-                            final subCat = cat.children![subIdx];
-                            return GestureDetector(
-                              onTap: () => Navigator.pushNamed(
-                                context,
-                                Routes.itemsList,
-                                arguments: {
-                                  'catID': subCat.id.toString(),
-                                  'catName': subCat.name,
-                                  'categoryIds': [subCat.id.toString()]
-                                },
+                        child: Builder(builder: (context) {
+                          if (isTablet) {
+                            return GridView.builder(
+                              shrinkWrap: true,
+                              physics: const NeverScrollableScrollPhysics(),
+                              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                                crossAxisCount: crossAxisCount,
+                                crossAxisSpacing: 6,
+                                mainAxisSpacing: 6,
                               ),
-                              child: Container(
+                              itemCount: cat.children?.length ?? 0,
+                              itemBuilder: (_, subIdx) {
+                                final subCat = cat.children![subIdx];
+                                return GestureDetector(
+                                  onTap: () => Navigator.pushNamed(
+                                    context,
+                                    Routes.itemsList,
+                                    arguments: {
+                                      'catID': subCat.id.toString(),
+                                      'catName': subCat.name,
+                                      'categoryIds': [subCat.id.toString()]
+                                    },
+                                  ),
+                                  child: Container(
+                                    margin: EdgeInsets.all(subMargin),
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(12),
+                                      boxShadow: [
+                                        BoxShadow(
+                                            color: Colors.black.withOpacity(.1),
+                                            blurRadius: 5,
+                                            offset: const Offset(0, 3))
+                                      ],
+                                    ),
+                                    child: ClipRRect(
+                                      borderRadius: BorderRadius.circular(12),
+                                      child: Stack(
+                                        children: [
+                                          Image.network(
+                                            subCat.url!,
+                                            fit: BoxFit.cover,
+                                            height: imageHeight,
+                                            width: double.infinity,
+                                            loadingBuilder: (context, child,
+                                                    progress) =>
+                                                progress == null
+                                                    ? child
+                                                    : const Center(
+                                                        child:
+                                                            CircularProgressIndicator()),
+                                          ),
+                                          Positioned(
+                                            bottom: 0,
+                                            left: 0,
+                                            right: 0,
+                                            child: Container(
+                                              padding: EdgeInsets.symmetric(
+                                                  vertical: isDesktop
+                                                      ? 8.0
+                                                      : isTablet
+                                                          ? 7.0
+                                                          : 6.0),
+                                              color: Colors.black.withOpacity(0.6),
+                                              child: Text(
+                                                subCat.name!,
+                                                textAlign: TextAlign.center,
+                                                style: TextStyle(
+                                                    color: Colors.white,
+                                                    fontSize: fontSizeSub,
+                                                    fontWeight: FontWeight.bold),
+                                              ),
+                                            ),
+                                          )
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              },
+                            );
+                          }
+                          return MasonryGridView.builder(
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            gridDelegate:
+                                SliverSimpleGridDelegateWithFixedCrossAxisCount(
+                                    crossAxisCount: crossAxisCount),
+                            itemCount: cat.children?.length ?? 0,
+                            itemBuilder: (_, subIdx) {
+                              final subCat = cat.children![subIdx];
+                              return GestureDetector(
+                                onTap: () => Navigator.pushNamed(
+                                  context,
+                                  Routes.itemsList,
+                                  arguments: {
+                                    'catID': subCat.id.toString(),
+                                    'catName': subCat.name,
+                                    'categoryIds': [subCat.id.toString()]
+                                  },
+                                ),
+                                child: Container(
                                 margin: EdgeInsets.all(subMargin),
                                 decoration: BoxDecoration(
                                   borderRadius: BorderRadius.circular(12),
@@ -485,10 +566,10 @@ class _AccordionGrid extends StatelessWidget {
                                     ],
                                   ),
                                 ),
-                              ),
-                            );
-                          },
-                        ),
+                              );
+                            },
+                          );
+                        }),
                       ),
               ),
             ],

--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -337,21 +337,37 @@ class HomeSectionsAdapter extends StatelessWidget {
 } else if (section.style == "style_3") {
   final items = section.sectionData ?? [];
   return items.isNotEmpty
-    ? MasonryGridView.builder(
-        padding: const EdgeInsets.symmetric(horizontal: sidePadding, vertical: 8),
-        gridDelegate: SliverSimpleGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: crossAxisCountStyle3,
-        ),
-        mainAxisSpacing: 12,
-        crossAxisSpacing: 12,
-        itemCount: items.length,
-        itemBuilder: (context, index) {
-          return ItemCard(
-            item: items[index],
-            width: cardWidthStyle3And4,
-          );
-        },
-      )
+    ? (isTablet
+        ? GridView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: sidePadding, vertical: 8),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCountStyle3,
+              mainAxisSpacing: 12,
+              crossAxisSpacing: 12,
+            ),
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              return ItemCard(
+                item: items[index],
+                width: cardWidthStyle3And4,
+              );
+            },
+          )
+        : MasonryGridView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: sidePadding, vertical: 8),
+            gridDelegate: SliverSimpleGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCountStyle3,
+            ),
+            mainAxisSpacing: 12,
+            crossAxisSpacing: 12,
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              return ItemCard(
+                item: items[index],
+                width: cardWidthStyle3And4,
+              );
+            },
+          ))
     : const SizedBox.shrink();
 }
 else if (section.style == "style_4") {

--- a/lib/ui/screens/home/widgets/item_horizontal_card.dart
+++ b/lib/ui/screens/home/widgets/item_horizontal_card.dart
@@ -169,7 +169,7 @@ class ItemHorizontalCard extends StatelessWidget {
           fit: StackFit.expand,
           children: [
             Column(
-              mainAxisSize: MainAxisSize.min,
+              mainAxisSize: MainAxisSize.max,
               children: [
                 Expanded(
                   child: Row(


### PR DESCRIPTION
## Summary
- prevent vertical overflow in `ItemHorizontalCard`
- use standard grid instead of Masonry on tablets for category lists
- add helper method for building subcategory items
- switch style 3 sections to regular grid on tablets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e72cd58408328b5bac2c6bf32f593