### PR TITLE
Display and track item view counts

### DIFF
--- a/lib/app/register_cubits.dart
+++ b/lib/app/register_cubits.dart
@@ -34,6 +34,7 @@ import 'package:Talab/data/cubits/item/fetch_my_item_cubit.dart';
 import 'package:Talab/data/cubits/item/fetch_my_promoted_items_cubit.dart';
 import 'package:Talab/data/cubits/item/fetch_popular_items_cubit.dart';
 import 'package:Talab/data/cubits/item/item_total_click_cubit.dart';
+import 'package:Talab/data/cubits/item/item_view_count_cubit.dart';
 import 'package:Talab/data/cubits/item/related_item_cubit.dart';
 import 'package:Talab/data/cubits/item/search_item_cubit.dart';
 import 'package:Talab/data/cubits/location/fetch_areas_cubit.dart';
@@ -108,6 +109,7 @@ class RegisterCubits {
     BlocProvider(create: (context) => FetchHomeAllItemsCubit()),
     BlocProvider(create: (context) => DeleteItemCubit()),
     BlocProvider(create: (context) => ItemTotalClickCubit()),
+    BlocProvider(create: (context) => ItemViewCountCubit()),
     BlocProvider(create: (context) => FetchSectionItemsCubit()),
     BlocProvider(create: (context) => ItemReportCubit()),
     BlocProvider(create: (context) => FetchRelatedItemsCubit()),

--- a/lib/data/cubits/item/item_view_count_cubit.dart
+++ b/lib/data/cubits/item/item_view_count_cubit.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../repositories/item/item_repository.dart';
+
+abstract class ItemViewCountState {}
+class ItemViewCountInitial extends ItemViewCountState {}
+class ItemViewCountLoading extends ItemViewCountState {}
+class ItemViewCountLoaded extends ItemViewCountState {
+  final Map<int, int> counts;
+  ItemViewCountLoaded(this.counts);
+}
+class ItemViewCountFailure extends ItemViewCountState {
+  final String error;
+  ItemViewCountFailure(this.error);
+}
+
+class ItemViewCountCubit extends Cubit<ItemViewCountState> {
+  final ItemRepository _repo = ItemRepository();
+  Map<int, int> counts = {};
+  ItemViewCountCubit() : super(ItemViewCountInitial());
+
+  Future<void> fetchViewCounts() async {
+    try {
+      emit(ItemViewCountLoading());
+      counts = await _repo.fetchItemViewCounts();
+      emit(ItemViewCountLoaded(counts));
+    } catch (e) {
+      emit(ItemViewCountFailure(e.toString()));
+    }
+  }
+
+  Future<void> increment(int itemId, {int views = 1}) async {
+    try {
+      await _repo.incrementItemView(itemId, views: views);
+      await fetchViewCounts();
+    } catch (e) {
+      emit(ItemViewCountFailure(e.toString()));
+    }
+  }
+}

--- a/lib/data/repositories/item/item_repository.dart
+++ b/lib/data/repositories/item/item_repository.dart
@@ -339,6 +339,33 @@ class ItemRepository {
     await Api.post(url: Api.setItemTotalClickApi, parameter: {Api.itemId: id});
   }
 
+  Future<Map<int, int>> fetchItemViewCounts() async {
+    final response =
+        await Api.get(url: Api.getItemViewCountsApi, queryParameters: {});
+    final Map<int, int> counts = {};
+    if (response['data'] is List) {
+      for (final item in response['data']) {
+        final int id = int.tryParse(item['item_id'].toString()) ??
+            int.tryParse(item['id'].toString()) ??
+            0;
+        final int view = int.tryParse(item['view_count'].toString()) ?? 0;
+        if (id != 0) counts[id] = view;
+      }
+    } else if (response['data'] is Map) {
+      (response['data'] as Map).forEach((key, value) {
+        final int id = int.tryParse(key.toString()) ?? 0;
+        final int view = int.tryParse(value.toString()) ?? 0;
+        if (id != 0) counts[id] = view;
+      });
+    }
+    return counts;
+  }
+
+  Future<void> incrementItemView(int id, {int views = 1}) async {
+    await Api.post(url: Api.incrementItemViewApi,
+        parameter: {Api.itemId: id, Api.totalView: views});
+  }
+
   Future<Map> makeAnOfferItem(int id, double? amount) async {
     Map response = await Api.post(
         url: Api.itemOfferApi,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:Talab/app/register_cubits.dart';
 import 'package:Talab/app/routes.dart';
 import 'package:Talab/data/cubits/system/app_theme_cubit.dart';
 import 'package:Talab/data/cubits/system/language_cubit.dart';
+import 'package:Talab/data/cubits/item/item_view_count_cubit.dart';
 import 'package:Talab/ui/screens/chat/chat_audio/globals.dart';
 import 'package:Talab/utils/constant.dart';
 import 'package:Talab/utils/hive_utils.dart';
@@ -64,6 +65,7 @@ class _AppState extends State<App> {
     AppTheme currentTheme = HiveUtils.getCurrentTheme();
 
     context.read<AppThemeCubit>().changeTheme(currentTheme);
+    context.read<ItemViewCountCubit>().fetchViewCounts();
 
     super.initState();
   }

--- a/lib/ui/screens/ad_details_screen.dart
+++ b/lib/ui/screens/ad_details_screen.dart
@@ -16,7 +16,7 @@ import 'package:Talab/data/cubits/item/create_featured_ad_cubit.dart';
 import 'package:Talab/data/cubits/item/delete_item_cubit.dart';
 import 'package:Talab/data/cubits/item/fetch_item_from_slug_cubit.dart';
 import 'package:Talab/data/cubits/item/fetch_my_item_cubit.dart';
-import 'package:Talab/data/cubits/item/item_total_click_cubit.dart';
+import 'package:Talab/data/cubits/item/item_view_count_cubit.dart';
 import 'package:Talab/data/cubits/item/related_item_cubit.dart';
 import 'package:Talab/data/cubits/renew_item_cubit.dart';
 import 'package:Talab/data/cubits/report/fetch_item_report_reason_list.dart';
@@ -237,7 +237,7 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
 
   void setItemClick() {
     if (!isAddedByMe) {
-      context.read<ItemTotalClickCubit>().itemTotalClick(model.id!);
+      context.read<ItemViewCountCubit>().increment(model.id!);
     }
   }
 
@@ -1998,12 +1998,15 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
                       const SizedBox(
                         width: 8,
                       ),
-                      CustomText(
-                        model.views != null ? model.views!.toString() : "0",
-                        color: context.color.textDefaultColor
-                            .withValues(alpha: 0.8),
-                        fontSize: context.font.large,
-                      )
+                      Builder(builder: (context) {
+                        final count = context.watch<ItemViewCountCubit>().counts[model.id] ?? model.views ?? 0;
+                        return CustomText(
+                          '$count',
+                          color: context.color.textDefaultColor
+                              .withValues(alpha: 0.8),
+                          fontSize: context.font.large,
+                        );
+                      })
                     ],
                   ))),
           SizedBox(width: 20),

--- a/lib/ui/screens/home/widgets/home_sections_adapter.dart
+++ b/lib/ui/screens/home/widgets/home_sections_adapter.dart
@@ -3,6 +3,7 @@ import 'package:Talab/app/routes.dart';
 import 'package:Talab/data/cubits/favorite/favorite_cubit.dart';
 import 'package:Talab/data/cubits/favorite/manage_fav_cubit.dart';
 import 'package:Talab/data/cubits/system/app_theme_cubit.dart';
+import 'package:Talab/data/cubits/item/item_view_count_cubit.dart';
 import 'package:Talab/data/model/home/home_screen_section.dart';
 import 'package:Talab/data/model/item/item_card_field.dart';
 import 'package:Talab/data/model/item/item_model.dart';
@@ -531,6 +532,23 @@ class _ItemCardState extends State<ItemCard> {
                         const SizedBox(height: 2),
                         _buildCardFieldsSection(context),
                       ],
+                      Builder(builder: (context) {
+                        final count = context.watch<ItemViewCountCubit>().counts[widget.item?.id] ?? widget.item?.views ?? 0;
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 2.0),
+                          child: Row(
+                            children: [
+                              UiUtils.getSvg(AppIcons.eye, width: 12, height: 12),
+                              const SizedBox(width: 4),
+                              CustomText(
+                                '$count',
+                                fontSize: addressFont,
+                                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                              ),
+                            ],
+                          ),
+                        );
+                      }),
                       const SizedBox(height: 2),
                     ],
                   ),
@@ -803,6 +821,23 @@ class _ExpandableHomeItemCardState extends State<ExpandableHomeItemCard>
                           .toList(),
                     ),
                   ],
+                  Builder(builder: (context) {
+                    final count = context.watch<ItemViewCountCubit>().counts[item?.id] ?? item?.views ?? 0;
+                    return Padding(
+                      padding: const EdgeInsets.only(top: 4.0),
+                      child: Row(
+                        children: [
+                          UiUtils.getSvg(AppIcons.eye, width: 12, height: 12),
+                          const SizedBox(width: 4),
+                          CustomText(
+                            '$count',
+                            fontSize: context.font.smaller,
+                            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                          ),
+                        ],
+                      ),
+                    );
+                  }),
                   Align(
                     alignment: Alignment.centerRight,
                     child: GestureDetector(

--- a/lib/ui/screens/home/widgets/item_horizontal_card.dart
+++ b/lib/ui/screens/home/widgets/item_horizontal_card.dart
@@ -14,6 +14,8 @@ import 'package:Talab/utils/extensions/extensions.dart';
 import 'package:Talab/utils/extensions/lib/currency_formatter.dart';
 import 'package:Talab/utils/ui_utils.dart';
 import 'package:Talab/utils/icon_mapper.dart';
+import 'package:Talab/data/cubits/item/item_view_count_cubit.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -267,6 +269,28 @@ class ItemHorizontalCard extends StatelessWidget {
                                 ),
                               if (item.cardFields != null && item.cardFields!.isNotEmpty)
                                  _buildCardFieldsSection(context),
+                              Builder(builder: (context) {
+                                final count = context.watch<ItemViewCountCubit>().counts[item.id] ?? item.views ?? 0;
+                                return Padding(
+                                  padding: const EdgeInsets.only(top: 6.0),
+                                  child: Row(
+                                    children: [
+                                      SvgPicture.asset(AppIcons.eye,
+                                          width: iconSize,
+                                          height: iconSize,
+                                          colorFilter: ColorFilter.mode(
+                                              context.color.textDefaultColor.withValues(alpha: 0.5),
+                                              BlendMode.srcIn)),
+                                      const SizedBox(width: 4),
+                                      CustomText(
+                                        '$count',
+                                        fontSize: fontSizeAddress,
+                                        color: context.color.textDefaultColor.withValues(alpha: 0.5),
+                                      )
+                                    ],
+                                  ),
+                                );
+                              }),
                             ],
                           ),
                         ),

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -89,6 +89,8 @@ class Api {
   static String addItemApi = "add-item";
   static String deleteItemApi = "delete-item";
   static String setItemTotalClickApi = "set-item-total-click";
+  static String getItemViewCountsApi = "item-view-counts";
+  static String incrementItemViewApi = "increment-item-view";
   static String makeItemFeaturedApi = "make-item-featured";
   static String assignFreePackageApi = "assign-free-package";
   static String getLimitsOfPackageApi = "get-limits";


### PR DESCRIPTION
## Summary
- add API endpoints for view count services
- implement repository methods to fetch and increment view counts
- create `ItemViewCountCubit` for managing counts
- register the cubit and initialize on app startup
- display view count on item cards and details screen
- increment view count when opening ad details

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e80dba838832897b115cdc8a6e369