### PR TITLE
Update item filtering logic

### DIFF
--- a/lib/ui/screens/item/items_list.dart
+++ b/lib/ui/screens/item/items_list.dart
@@ -75,6 +75,7 @@ class ItemsListState extends State<ItemsList> {
       MediaQuery.of(context).size.shortestSide >= 600;
 
   void _applyFilters() {
+    ItemFilterModel base = filter ?? ItemFilterModel.createEmpty();
     Map<String, dynamic> fields = {};
     _selectedFilters.forEach((key, value) {
       fields['custom_fields[' + key.toString() + ']'] = [value];
@@ -82,11 +83,15 @@ class ItemsListState extends State<ItemsList> {
     if (_adTypeId != null && _selectedAdType != null) {
       fields['custom_fields[' + _adTypeId.toString() + ']'] = [_selectedAdType];
     }
+    filter = base.copyWith(
+      customFields: {...?base.customFields, ...fields},
+      categoryId: widget.categoryId,
+    );
     context.read<FetchItemFromCategoryCubit>().fetchItemFromCategory(
-        categoryId: int.parse(widget.categoryId),
-        search: searchController.text,
-        filter: ItemFilterModel(
-            categoryId: widget.categoryId, customFields: fields));
+      categoryId: int.parse(widget.categoryId),
+      search: searchController.text,
+      filter: filter,
+    );
   }
 
   Widget _buildFilterBar() {

--- a/lib/ui/screens/sub_category/sub_category_screen.dart
+++ b/lib/ui/screens/sub_category/sub_category_screen.dart
@@ -67,6 +67,7 @@ class _CategoryListState extends State<SubCategoryScreen>
   String? _selectedAdType;
   int _totalAds = 0;
   final Map<int, dynamic> _selectedFilters = {};
+  ItemFilterModel? _filter;
 
   @override
   void initState() {
@@ -77,10 +78,11 @@ class _CategoryListState extends State<SubCategoryScreen>
     context
         .read<FetchCustomFieldsCubit>()
         .fetchCustomFields(categoryIds: widget.categoryIds.join(','));
+    _filter = ItemFilterModel(categoryId: widget.catId.toString());
     context.read<FetchItemFromCategoryCubit>().fetchItemFromCategory(
         categoryId: widget.catId,
         search: '',
-        filter: ItemFilterModel(categoryId: widget.catId.toString()));
+        filter: _filter);
     super.initState();
   }
 
@@ -103,18 +105,23 @@ class _CategoryListState extends State<SubCategoryScreen>
   }
 
   void _applyFilters() {
+    ItemFilterModel base = _filter ?? ItemFilterModel.createEmpty();
     Map<String, dynamic> fields = {};
     _selectedFilters.forEach((key, value) {
-      fields['custom_fields[$key]'] = [value];
+      fields['custom_fields[' + key.toString() + ']'] = [value];
     });
     if (_adTypeId != null && _selectedAdType != null) {
       fields['custom_fields[' + _adTypeId.toString() + ']'] = [_selectedAdType];
     }
+    _filter = base.copyWith(
+      customFields: {...?base.customFields, ...fields},
+      categoryId: widget.catId.toString(),
+    );
     context.read<FetchItemFromCategoryCubit>().fetchItemFromCategory(
-        categoryId: widget.catId,
-        search: '',
-        filter: ItemFilterModel(
-            categoryId: widget.catId.toString(), customFields: fields));
+      categoryId: widget.catId,
+      search: '',
+      filter: _filter,
+    );
   }
 
   Widget _buildFilterBar() {


### PR DESCRIPTION
## Summary
- improve _applyFilters() in items list
- add filtering state to subcategory screen
- reuse filtering logic when applying custom field filters

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd84cc0148328949a2fb62a9bc3c7