### PR TITLE
Fix related ads loading crash

### DIFF
--- a/lib/ui/screens/ad_details_screen.dart
+++ b/lib/ui/screens/ad_details_screen.dart
@@ -179,7 +179,6 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
         areaId: HiveUtils.getAreaId(),
         country: HiveUtils.getCountryName(),
         state: HiveUtils.getStateName());
-    _pageScrollController.addListener(_pageScroll);
   }
 
   void _pageScroll() {
@@ -198,6 +197,12 @@ class AdDetailsScreenState extends CloudState<AdDetailsScreen> {
 
   @override
   void dispose() {
+    _pageScrollController.removeListener(_pageScroll);
+    _pageScrollController.dispose();
+    pageController.dispose();
+    _reportmessageController.dispose();
+    _makeAnOffermessageController.dispose();
+    flickManager?.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- fix duplication of scroll listener in ad details screen
- dispose controllers and video player manager properly

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4ccee2083289c53fbc258732bf8