### PR TITLE
Improve splash data prefetch

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -75,15 +75,22 @@ class HomeScreenState extends State<HomeScreen>
     notificationPermissionChecker();
     LocalAwesomeNotification().init(context);
     NotificationService.init(context);
-    context.read<SliderCubit>().fetchSlider(context);
-    context.read<FetchCategoryCubit>().fetchCategories();
-    context.read<FetchHomeScreenCubit>().fetch(
+    if (context.read<SliderCubit>().state is! SliderFetchSuccess) {
+      context.read<SliderCubit>().fetchSlider(context);
+    }
+    if (context.read<FetchCategoryCubit>().state is! FetchCategorySuccess) {
+      context.read<FetchCategoryCubit>().fetchCategories();
+    }
+    if (context.read<FetchHomeScreenCubit>().state is! FetchHomeScreenSuccess) {
+      context.read<FetchHomeScreenCubit>().fetch(
           city: HiveUtils.getCityName(),
           areaId: HiveUtils.getAreaId(),
           country: HiveUtils.getCountryName(),
           state: HiveUtils.getStateName(),
         );
-    context.read<FetchHomeAllItemsCubit>().fetch(
+    }
+    if (context.read<FetchHomeAllItemsCubit>().state is! FetchHomeAllItemsSuccess) {
+      context.read<FetchHomeAllItemsCubit>().fetch(
           city: HiveUtils.getCityName(),
           areaId: HiveUtils.getAreaId(),
           radius: HiveUtils.getNearbyRadius(),
@@ -92,6 +99,7 @@ class HomeScreenState extends State<HomeScreen>
           country: HiveUtils.getCountryName(),
           state: HiveUtils.getStateName(),
         );
+    }
 
     if (HiveUtils.isUserAuthenticated()) {
       context.read<FavoriteCubit>().getFavorite();

--- a/lib/ui/screens/splash_screen.dart
+++ b/lib/ui/screens/splash_screen.dart
@@ -6,6 +6,13 @@ import 'package:Talab/app/routes.dart';
 import 'package:Talab/data/cubits/system/fetch_language_cubit.dart';
 import 'package:Talab/data/cubits/system/fetch_system_settings_cubit.dart';
 import 'package:Talab/data/cubits/system/language_cubit.dart';
+import 'package:Talab/data/cubits/favorite/favorite_cubit.dart';
+import 'package:Talab/data/cubits/chat/blocked_users_list_cubit.dart';
+import 'package:Talab/data/cubits/chat/get_buyer_chat_users_cubit.dart';
+import 'package:Talab/data/cubits/slider_cubit.dart';
+import 'package:Talab/data/cubits/category/fetch_category_cubit.dart';
+import 'package:Talab/data/cubits/home/fetch_home_all_items_cubit.dart';
+import 'package:Talab/data/cubits/home/fetch_home_screen_cubit.dart';
 import 'package:Talab/data/model/system_settings_model.dart';
 import 'package:Talab/ui/screens/widgets/errors/no_internet.dart';
 import 'package:Talab/utils/constant.dart';
@@ -27,6 +34,8 @@ class SplashScreenState extends State<SplashScreen> with TickerProviderStateMixi
   bool isTimerCompleted = false;
   bool isSettingsLoaded = false;
   bool isLanguageLoaded = false;
+  bool isHomeDataLoaded = false;
+  bool _startedHomeFetch = false;
   late StreamSubscription<List<ConnectivityResult>> subscription;
   bool hasInternet = true;
 
@@ -99,6 +108,50 @@ class SplashScreenState extends State<SplashScreen> with TickerProviderStateMixi
     }
   }
 
+  void startHomeDataFetch() {
+    if (_startedHomeFetch) return;
+    _startedHomeFetch = true;
+    // Prefetch home screen related data
+    context.read<SliderCubit>().fetchSlider(context);
+    context.read<FetchCategoryCubit>().fetchCategories();
+    context.read<FetchHomeScreenCubit>().fetch(
+          city: HiveUtils.getCityName(),
+          areaId: HiveUtils.getAreaId(),
+          country: HiveUtils.getCountryName(),
+          state: HiveUtils.getStateName(),
+        );
+    context.read<FetchHomeAllItemsCubit>().fetch(
+          city: HiveUtils.getCityName(),
+          areaId: HiveUtils.getAreaId(),
+          radius: HiveUtils.getNearbyRadius(),
+          longitude: HiveUtils.getLongitude(),
+          latitude: HiveUtils.getLatitude(),
+          country: HiveUtils.getCountryName(),
+          state: HiveUtils.getStateName(),
+        );
+
+    if (HiveUtils.isUserAuthenticated()) {
+      context.read<FavoriteCubit>().getFavorite();
+      context.read<GetBuyerChatListCubit>().fetch();
+      context.read<BlockedUsersListCubit>().blockedUsersList();
+    }
+  }
+
+  bool _checkHomeDataLoaded() {
+    final sliderLoaded = context.read<SliderCubit>().state is SliderFetchSuccess ||
+        context.read<SliderCubit>().state is SliderFetchFailure;
+    final categoryLoaded =
+        context.read<FetchCategoryCubit>().state is FetchCategorySuccess ||
+            context.read<FetchCategoryCubit>().state is FetchCategoryFailure;
+    final homeScreenLoaded =
+        context.read<FetchHomeScreenCubit>().state is FetchHomeScreenSuccess ||
+            context.read<FetchHomeScreenCubit>().state is FetchHomeScreenFail;
+    final homeItemsLoaded = context.read<FetchHomeAllItemsCubit>().state is FetchHomeAllItemsSuccess ||
+        context.read<FetchHomeAllItemsCubit>().state is FetchHomeAllItemsFail;
+
+    return sliderLoaded && categoryLoaded && homeScreenLoaded && homeItemsLoaded;
+  }
+
   Future<void> startTimer() async {
     // Minimum display time for splash, or can be tied to video
     Timer(const Duration(milliseconds: 500), () {
@@ -111,7 +164,7 @@ class SplashScreenState extends State<SplashScreen> with TickerProviderStateMixi
   void navigateCheck() {
     if (_hasNavigated) return;
     // Only navigate when all are true and video finished
-    if (isTimerCompleted && isSettingsLoaded && isLanguageLoaded) {
+    if (isTimerCompleted && isSettingsLoaded && isLanguageLoaded && isHomeDataLoaded) {
       _hasNavigated = true;
       navigateToScreen();
     }
@@ -153,53 +206,87 @@ class SplashScreenState extends State<SplashScreen> with TickerProviderStateMixi
   Widget build(BuildContext context) {
     navigateCheck();
     return hasInternet
-        ? BlocListener<FetchLanguageCubit, FetchLanguageState>(
-            listener: (context, state) {
-              if (state is FetchLanguageSuccess) {
-                Map<String, dynamic> map = state.toMap();
-                var data = map['file_name'];
-                map['data'] = data;
-                map.remove("file_name");
-                HiveUtils.storeLanguage(map);
-                context.read<LanguageCubit>().changeLanguages(map);
-                isLanguageLoaded = true;
-                if (mounted) {
-                  setState(() {});
-                  navigateCheck();
-                }
-              }
-            },
-            child: BlocListener<FetchSystemSettingsCubit, FetchSystemSettingsState>(
-              listener: (context, state) {
-                if (state is FetchSystemSettingsSuccess) {
-                  Constant.isDemoModeOn = context.read<FetchSystemSettingsCubit>().getSetting(SystemSetting.demoMode);
-                  getDefaultLanguage(state.settings['data']['default_language']);
-                  isSettingsLoaded = true;
-                  setState(() {});
-                  navigateCheck();
-                }
-                if (state is FetchSystemSettingsFailure) {}
-              },
-              child: AnnotatedRegion(
-                value: SystemUiOverlayStyle(
-                  statusBarColor: Colors.black, // or context.color.territoryColor
-                ),
-                child: Scaffold(
-                  backgroundColor: Colors.black,
-                  body: Center(
-                    child: _isVideoInitialized
-                        ? SizedBox.expand(
-                            child: FittedBox(
-                              fit: BoxFit.cover,
-                              child: SizedBox(
-                                width: _videoController.value.size.width,
-                                height: _videoController.value.size.height,
-                                child: VideoPlayer(_videoController),
-                              ),
+        ? MultiBlocListener(
+            listeners: [
+              BlocListener<FetchLanguageCubit, FetchLanguageState>(
+                listener: (context, state) {
+                  if (state is FetchLanguageSuccess) {
+                    Map<String, dynamic> map = state.toMap();
+                    var data = map['file_name'];
+                    map['data'] = data;
+                    map.remove("file_name");
+                    HiveUtils.storeLanguage(map);
+                    context.read<LanguageCubit>().changeLanguages(map);
+                    isLanguageLoaded = true;
+                    setState(() {});
+                    navigateCheck();
+                  }
+                },
+              ),
+              BlocListener<FetchSystemSettingsCubit, FetchSystemSettingsState>(
+                listener: (context, state) {
+                  if (state is FetchSystemSettingsSuccess) {
+                    Constant.isDemoModeOn = context.read<FetchSystemSettingsCubit>().getSetting(SystemSetting.demoMode);
+                    getDefaultLanguage(state.settings['data']['default_language']);
+                    isSettingsLoaded = true;
+                    setState(() {});
+                    navigateCheck();
+                    startHomeDataFetch();
+                  }
+                },
+              ),
+              BlocListener<SliderCubit, SliderState>(
+                listener: (context, state) {
+                  if (state is SliderFetchSuccess || state is SliderFetchFailure) {
+                    isHomeDataLoaded = _checkHomeDataLoaded();
+                    navigateCheck();
+                  }
+                },
+              ),
+              BlocListener<FetchCategoryCubit, FetchCategoryState>(
+                listener: (context, state) {
+                  if (state is FetchCategorySuccess || state is FetchCategoryFailure) {
+                    isHomeDataLoaded = _checkHomeDataLoaded();
+                    navigateCheck();
+                  }
+                },
+              ),
+              BlocListener<FetchHomeScreenCubit, FetchHomeScreenState>(
+                listener: (context, state) {
+                  if (state is FetchHomeScreenSuccess || state is FetchHomeScreenFail) {
+                    isHomeDataLoaded = _checkHomeDataLoaded();
+                    navigateCheck();
+                  }
+                },
+              ),
+              BlocListener<FetchHomeAllItemsCubit, FetchHomeAllItemsState>(
+                listener: (context, state) {
+                  if (state is FetchHomeAllItemsSuccess || state is FetchHomeAllItemsFail) {
+                    isHomeDataLoaded = _checkHomeDataLoaded();
+                    navigateCheck();
+                  }
+                },
+              ),
+            ],
+            child: AnnotatedRegion(
+              value: const SystemUiOverlayStyle(
+                statusBarColor: Colors.black,
+              ),
+              child: Scaffold(
+                backgroundColor: Colors.black,
+                body: Center(
+                  child: _isVideoInitialized
+                      ? SizedBox.expand(
+                          child: FittedBox(
+                            fit: BoxFit.cover,
+                            child: SizedBox(
+                              width: _videoController.value.size.width,
+                              height: _videoController.value.size.height,
+                              child: VideoPlayer(_videoController),
                             ),
-                          )
-                        : Container(),
-                  ),
+                          ),
+                        )
+                      : Container(),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- preload home page data during splash screen
- add helper for checking data load state
- wait for preloading completion before navigating
- skip repeated data fetches when home screen opens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852dcfe605c8328864c6deaa6e6a8f4