### PR TITLE
Fix Content-Language header and card field translation

### DIFF
--- a/lib/data/model/item/item_card_field.dart
+++ b/lib/data/model/item/item_card_field.dart
@@ -6,7 +6,7 @@ class ItemCardField {
   ItemCardField({this.name, this.icon, this.value});
 
   factory ItemCardField.fromJson(Map<String, dynamic> json) {
-    var value = json['value'];
+    var value = json['translated_value'] ?? json['value'];
     String? processedValue;
     if (value is List && value.isNotEmpty) {
       // Extract the first value from the list and convert to string
@@ -16,7 +16,7 @@ class ItemCardField {
       processedValue = value.toString();
     }
     return ItemCardField(
-      name: json['name'],
+      name: json['translated_name'] ?? json['name'],
       icon: json['icon'],
       value: processedValue,
     );

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -27,27 +27,23 @@ class ApiException implements Exception {
 
 class Api {
   static Map<String, dynamic> headers() {
-    if (!HiveUtils.isUserAuthenticated()) {
-      if (HiveUtils.getLanguage() != null ||
-          HiveUtils.getLanguage()?['data'] != null) {
-        return {
-          "Accept": "application/json",
-          "Content-Language": HiveUtils.getLanguage()['code'] ?? ""
-        };
-      } else {
-        return {};
-      }
-    } else {
+    final lang = HiveUtils.getLanguage();
+    final String langCode =
+        lang != null && lang['code'] != null && lang['code'].toString().isNotEmpty
+            ? lang['code']
+            : 'en';
+
+    final Map<String, dynamic> header = {
+      "Accept": "application/json",
+      "Content-Language": langCode
+    };
+
+    if (HiveUtils.isUserAuthenticated()) {
       String? jwtToken = HiveUtils.getJWT();
-
-      print("jwt token****$jwtToken");
-
-      return {
-        "Authorization": "Bearer $jwtToken",
-        "Accept": "application/json",
-        "Content-Language": HiveUtils.getLanguage()['code'] ?? ""
-      };
+      header["Authorization"] = "Bearer $jwtToken";
     }
+
+    return header;
   }
 
 //Place API


### PR DESCRIPTION
## Summary
- always set `Content-Language` header based on selected language
- use `translated_name` and `translated_value` for card fields

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566c2d51608328a4727cf74664ea25